### PR TITLE
Add CRUD endpoints for menu items

### DIFF
--- a/backend/src/controllers/menuController.ts
+++ b/backend/src/controllers/menuController.ts
@@ -1,19 +1,14 @@
 import { Request, Response } from "express";
 import { pool } from "../db";
-import { MenuItem } from "../types/menu";
+import { MenuItem, MenuItemInput } from "../types/menu";
 import { Category } from "../types/category";
 
 export const getMenuItems = async (req: Request, res: Response) => {
   try {
-    // Fetch all menu categories from the database
-    const categoriesResult = await pool.query<Category>(
-      "SELECT * FROM categories"
-    );
+    const categoriesResult = await pool.query<Category>("SELECT * FROM categories");
     const categories = categoriesResult.rows;
-    // Fetch all menu items from the database
     const itemsResult = await pool.query<MenuItem>("SELECT * FROM menu_items");
     const items = itemsResult.rows;
-    // group menu items by category
     const groupedMenuItems = categories.map((category) => ({
       ...category,
       items: items.filter((item: MenuItem) => item.category_id === category.id),
@@ -21,6 +16,76 @@ export const getMenuItems = async (req: Request, res: Response) => {
     res.json(groupedMenuItems);
   } catch (error) {
     console.error("Error fetching menu items:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const getMenuItemById = async (req: Request, res: Response) => {
+  const id = req.params.id;
+  try {
+    const result = await pool.query<MenuItem>("SELECT * FROM menu_items WHERE id = $1", [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: "Menu item not found" });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error("Error fetching menu item:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const createMenuItem = async (req: Request, res: Response) => {
+  const { name, price, abv, description, image_url, category_id } = req.body as MenuItemInput;
+  try {
+    const result = await pool.query<MenuItem>(
+      "INSERT INTO menu_items (name, price, abv, description, image_url, category_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *",
+      [name, price, abv, description, image_url, category_id]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (error) {
+    console.error("Error creating menu item:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const updateMenuItem = async (req: Request, res: Response) => {
+  const id = req.params.id;
+  const { name, price, abv, description, image_url, category_id } = req.body as MenuItemInput;
+  try {
+    const result = await pool.query<MenuItem>(
+      "UPDATE menu_items SET name=$1, price=$2, abv=$3, description=$4, image_url=$5, category_id=$6 WHERE id=$7 RETURNING *",
+      [name, price, abv, description, image_url, category_id, id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: "Menu item not found" });
+    }
+    res.json(result.rows[0]);
+  } catch (error) {
+    console.error("Error updating menu item:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const deleteMenuItem = async (req: Request, res: Response) => {
+  const id = req.params.id;
+  try {
+    const result = await pool.query<MenuItem>("DELETE FROM menu_items WHERE id = $1 RETURNING *", [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: "Menu item not found" });
+    }
+    res.json({ message: "Menu item deleted", item: result.rows[0] });
+  } catch (error) {
+    console.error("Error deleting menu item:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const getCategories = async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query<Category>("SELECT * FROM categories");
+    res.json(result.rows);
+  } catch (error) {
+    console.error("Error fetching categories:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 };

--- a/backend/src/routes/menu.ts
+++ b/backend/src/routes/menu.ts
@@ -1,8 +1,20 @@
 import express from "express";
-import { getMenuItems } from "../controllers/menuController";
+import {
+  getMenuItems,
+  getMenuItemById,
+  createMenuItem,
+  updateMenuItem,
+  deleteMenuItem,
+  getCategories,
+} from "../controllers/menuController";
 
 const router = express.Router();
 
 router.get("/", getMenuItems);
+router.get("/categories", getCategories);
+router.get("/:id", getMenuItemById);
+router.post("/", createMenuItem);
+router.put("/:id", updateMenuItem);
+router.delete("/:id", deleteMenuItem);
 
 export default router;

--- a/backend/src/types/menu.ts
+++ b/backend/src/types/menu.ts
@@ -9,3 +9,12 @@ export interface MenuItem {
   created_at: Date;
   updated_at: Date;
 }
+
+export interface MenuItemInput {
+  name: string;
+  price: number;
+  abv: number;
+  description: string;
+  image_url: string;
+  category_id: number;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { IonReactRouter } from '@ionic/react-router';
 import { Redirect, Route } from 'react-router-dom';
 import Menu from './components/Menu';
 import Page from './pages/Page';
+import Admin from './pages/Admin';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -45,6 +46,9 @@ const App: React.FC = () => {
           <IonRouterOutlet id="main">
             <Route path="/" exact={true}>
               <Redirect to="/folder/Inbox" />
+            </Route>
+            <Route path="/admin" exact={true}>
+              <Admin />
             </Route>
             <Route path="/folder/:name" exact={true}>
               <Page />

--- a/frontend/src/components/Menu.tsx
+++ b/frontend/src/components/Menu.tsx
@@ -57,6 +57,12 @@ const appPages: AppPage[] = [
     url: '/folder/Spam',
     iosIcon: warningOutline,
     mdIcon: warningSharp
+  },
+  {
+    title: 'Admin',
+    url: '/admin',
+    iosIcon: archiveOutline,
+    mdIcon: archiveSharp
   }
 ];
 

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,0 +1,18 @@
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/react';
+
+const Admin: React.FC = () => {
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Admin</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent fullscreen>
+        <p style={{ padding: '1rem' }}>Admin dashboard placeholder</p>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Admin;


### PR DESCRIPTION
## Summary
- extend `MenuItem` types to include `MenuItemInput`
- implement CRUD endpoints in `menuController`
- expose new menu routes
- add a minimal admin page and route

## Testing
- `npm run build` in `backend` *(fails: Cannot find module 'express' ...)*
- `npm run build` in `frontend` *(fails: Cannot find module 'react' ...)*


------
https://chatgpt.com/codex/tasks/task_e_68404622caa08330bf0073666e3c0d33